### PR TITLE
Develop marco

### DIFF
--- a/Functional_Fusion/atlas_map.py
+++ b/Functional_Fusion/atlas_map.py
@@ -375,6 +375,10 @@ class AtlasVolumetric(Atlas):
                 img, self.world[0, :], self.world[1, :], self.world[2, :],
                 interpolation
             )
+        if isinstance(img, list):
+            data = nt.sample_images(
+                img, self.world
+            )
         else:
             raise(NameError("Unknown image type"))
         return data.T # Return the data as NxP array

--- a/Functional_Fusion/atlas_map.py
+++ b/Functional_Fusion/atlas_map.py
@@ -1244,10 +1244,26 @@ def exclude_overlapping_voxels(amap, exclude='all', exclude_thres=0.9):
         vox_j, weight_j = amap[j].vox_list, amap[j].vox_weight
         vox_k, weight_k = amap[k].vox_list, amap[k].vox_weight
 
-        EQ = vox_j.flatten()[:, np.newaxis] == vox_k.flatten()[np.newaxis, :]
+        # EQ = vox_j.flatten()[:, np.newaxis] == vox_k.flatten()[np.newaxis, :]
+        #
+        # idx_j, idx_k = np.where(EQ)
+        vox_j = vox_j.flatten()
+        vox_k = vox_k.flatten()
 
-        idx_j, idx_k = np.where(EQ)
+        # Sort vox_k and keep track of the original indices
+        sort_idx = np.argsort(vox_k)
+        vox_k_sorted = vox_k[sort_idx]
 
+        # Check which elements in vox_j exist in vox_k
+        mask = np.isin(vox_j, vox_k_sorted)
+
+        # Find the corresponding indices in vox_k
+        idx_j = np.where(mask)[0]  # Indices in vox_j
+        idx_k = np.searchsorted(vox_k_sorted, vox_j[mask])  # Indices in sorted vox_k
+
+        # Convert back to original vox_k indices
+        idx_k = sort_idx[idx_k]
+        
         print(f'found {len(idx_j)} overlapping voxels')
 
         for idx_j_v, idx_k_v in zip(idx_j, idx_k):

--- a/Functional_Fusion/dataset.py
+++ b/Functional_Fusion/dataset.py
@@ -229,7 +229,7 @@ def agg_data(info, by, over, subset=None):
     return data_info, C
 
 
-def agg_parcels(data, label_vec, fcn=np.nanmean, *args, **kwargs):
+def agg_parcels(data, label_vec, fcn=np.nanmean, **kwargs):
     """ Aggregates data over colums to condense to parcels
 
     Args:
@@ -248,7 +248,7 @@ def agg_parcels(data, label_vec, fcn=np.nanmean, *args, **kwargs):
     parcel_data = np.zeros(psize)
     for i, l in enumerate(labels):
         parcel_data[..., i] = fcn(
-            data[..., label_vec == l], axis=len(psize) - 1, *args, **kwargs)
+            data[..., label_vec == l], axis=len(psize) - 1, **kwargs)
     return parcel_data, labels
 
 def combine_parcel_labels(labels_org,labels_new, labelvec_org=None):

--- a/Functional_Fusion/dataset.py
+++ b/Functional_Fusion/dataset.py
@@ -229,7 +229,7 @@ def agg_data(info, by, over, subset=None):
     return data_info, C
 
 
-def agg_parcels(data, label_vec, fcn=np.nanmean):
+def agg_parcels(data, label_vec, fcn=np.nanmean, *args, **kwargs):
     """ Aggregates data over colums to condense to parcels
 
     Args:
@@ -248,7 +248,7 @@ def agg_parcels(data, label_vec, fcn=np.nanmean):
     parcel_data = np.zeros(psize)
     for i, l in enumerate(labels):
         parcel_data[..., i] = fcn(
-            data[..., label_vec == l], axis=len(psize) - 1)
+            data[..., label_vec == l], axis=len(psize) - 1, *args, **kwargs)
     return parcel_data, labels
 
 def combine_parcel_labels(labels_org,labels_new, labelvec_org=None):


### PR DESCRIPTION
- Changed the way voxel weights are computed when atlas is built. It now reflects the number of vertices each voxel maps to. Before, voxel weights were often similar, which lead to over exclusion of voxels when overlapping between two rois. Previous code is still there commented for reference
- Made exclusion of overlapping voxels between ROIs more efficient
- Made agg_parcels in dataset more flexible in terms of arguments fcn can have (using **kwargs)