### PR TITLE
fixing bug in read_data atlas_map.py

### DIFF
--- a/Functional_Fusion/atlas_map.py
+++ b/Functional_Fusion/atlas_map.py
@@ -638,7 +638,7 @@ class AtlasSurface(Atlas):
                 raise (NameError("Need to pass a Cifti file or list of giftis"))
             else:
                 img = [img]
-        if isinstance(img, list):
+        elif isinstance(img, list):
             if len(img) != len(self.structure):
                 raise (NameError("Number of images needs to match len(self.structure)"))
             data = []


### PR DESCRIPTION
read-data fails on single GIFTI or CIFTI files as it check for lists anyways -> changing to `elif`